### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ ___
 ### [pipx](https://github.com/pipxproject/pipx#install-pipx)
 Persistent install:
 
-`pipx install git+https://github.com/benbusby/whoogle-search.git`
+`pipx install https://github.com/benbusby/whoogle-search/archive/refs/heads/main.zip`
 
 Sandboxed temporary instance:
 


### PR DESCRIPTION
If `pipx install git+<link>` is used, the user must have git installed, otherwise the package cannot be installed. In the case of a direct link to the archive, this is not required.